### PR TITLE
CMS Security Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,7 +372,7 @@ function cms(loopbackApplication, options) {
         relationalUpsert.upsert(data, function(error, response) {
           if (error) {
             if (error.code) {
-              res.status(code).send(error);
+              res.status(error.code).send(error);
             } else {
               res.status(500).send(error);
             }

--- a/index.js
+++ b/index.js
@@ -371,7 +371,11 @@ function cms(loopbackApplication, options) {
       function upsertData() {
         relationalUpsert.upsert(data, function(error, response) {
           if (error) {
-            res.status(500).send(error);
+            if (error.code) {
+              res.status(code).send(error);
+            } else {
+              res.status(500).send(error);
+            }
           } else {
             res.send(response);
           }

--- a/server/relational-upsert.js
+++ b/server/relational-upsert.js
@@ -98,7 +98,7 @@ function start(model, data, callback) {
   if (!whitelist.includes(model.definition.name)) {
     var message = "cannot update a model not on the whitelist: '"+model.definition.name+"'";
     console.error("ERROR: " + message);
-    callback({ error: message });
+    callback({ error: message, code: 403 });
     return; 
   }
 

--- a/server/relational-upsert.js
+++ b/server/relational-upsert.js
@@ -36,6 +36,7 @@ const whitelist = [
   'Sponsor',
   'Vendor',
   'Contact',
+  'Trial',
   'AdverseEvent',
   'ContactTypes',
   'Diagnosis',

--- a/server/relational-upsert.js
+++ b/server/relational-upsert.js
@@ -93,6 +93,14 @@ function upsert(data, callback) {
  */
 function start(model, data, callback) {
   var index = 0;
+
+  if (whitelist.includes(model.definition.name)) {
+    var message = "cannot update a model not on the whitelist: '"+model.definition.name+"'";
+    console.error("ERROR: " + message);
+    callback({ error: message });
+    return; 
+  }
+
   next(RELATIONSHIP_SINGLE, model, data, index, function(error, count) {
     //After inserting all one-to-many relationships, perform the primary model upsert
     model.upsert(data, function(error, result) {

--- a/server/relational-upsert.js
+++ b/server/relational-upsert.js
@@ -94,7 +94,7 @@ function upsert(data, callback) {
 function start(model, data, callback) {
   var index = 0;
 
-  console.log("attempting to upsert: "+model.definition.name);
+  console.log("attempting to upsert model: "+model.definition.name);
   if (!whitelist.includes(model.definition.name)) {
     var message = "cannot update a model not on the whitelist: '"+model.definition.name+"'";
     console.error("ERROR: " + message);
@@ -162,6 +162,14 @@ function next(processRelationshipType, model, data, index, callback) {
     index++;
     next(processRelationshipType, model, data, index, callback);
     return;
+  }
+
+  console.log("attempting to upsert relationshipModel: "+relationshipModel.definition.name);
+  if (!whitelist.includes(model.definition.name)) {
+    var message = "cannot update a relationshipModel not on the whitelist: '"+relationshipModel.definition.name+"'";
+    console.error("ERROR: " + message);
+    callback({ error: message, code: 403 }, index);
+    return; 
   }
 
   if (processRelationshipType == RELATIONSHIP_SINGLE) {
@@ -316,6 +324,14 @@ function upsertManyToMany(model, data, relationshipKey, relationshipData, relati
  * @param callback
  */
 function nextManyToMany(junctionModel, junctionModelIdKey, junctionRelationIdKey, relationIdKey, modelId, relationshipData, index, callback) {
+  console.log("attempting to upsert junctionModel: "+relationshipModel.definition.name);
+  if (!whitelist.includes(junctionModel.definition.name)) {
+    var message = "cannot update a relationshipModel not on the whitelist: '"+junctionModel.definition.name+"'";
+    console.error("ERROR: " + message);
+    callback({ error: message, code: 403 }, 0);
+    return; 
+  }
+
   if (!relationshipData) {
     callback(null, 0)
     return

--- a/server/relational-upsert.js
+++ b/server/relational-upsert.js
@@ -94,7 +94,8 @@ function upsert(data, callback) {
 function start(model, data, callback) {
   var index = 0;
 
-  if (whitelist.includes(model.definition.name)) {
+  console.log("attempting to upsert: "+model.definition.name);
+  if (!whitelist.includes(model.definition.name)) {
     var message = "cannot update a model not on the whitelist: '"+model.definition.name+"'";
     console.error("ERROR: " + message);
     callback({ error: message });

--- a/server/relational-upsert.js
+++ b/server/relational-upsert.js
@@ -94,7 +94,6 @@ function upsert(data, callback) {
 function start(model, data, callback) {
   var index = 0;
 
-  console.log("attempting to upsert model: "+model.definition.name);
   if (!whitelist.includes(model.definition.name)) {
     var message = "cannot update a model not on the whitelist: '"+model.definition.name+"'";
     console.error("ERROR: " + message);
@@ -164,7 +163,6 @@ function next(processRelationshipType, model, data, index, callback) {
     return;
   }
 
-  console.log("attempting to upsert relationshipModel: "+relationshipModel.definition.name);
   if (!whitelist.includes(model.definition.name)) {
     var message = "cannot update a relationshipModel not on the whitelist: '"+relationshipModel.definition.name+"'";
     console.error("ERROR: " + message);
@@ -324,7 +322,6 @@ function upsertManyToMany(model, data, relationshipKey, relationshipData, relati
  * @param callback
  */
 function nextManyToMany(junctionModel, junctionModelIdKey, junctionRelationIdKey, relationIdKey, modelId, relationshipData, index, callback) {
-  console.log("attempting to upsert junctionModel: "+relationshipModel.definition.name);
   if (!whitelist.includes(junctionModel.definition.name)) {
     var message = "cannot update a relationshipModel not on the whitelist: '"+junctionModel.definition.name+"'";
     console.error("ERROR: " + message);

--- a/server/relational-upsert.js
+++ b/server/relational-upsert.js
@@ -30,6 +30,19 @@ var RELATIONSHIP_MANY = "RELATIONSHIP_MANY";
 var relationshipKeys = [];
 var relationshipManyToManyKeys = [];
 
+const whitelist = [
+  'Lead',
+  'Site',
+  'Sponsor',
+  'Vendor',
+  'Contact',
+  'AdverseEvent',
+  'ContactTypes',
+  'Diagnosis',
+  'Medication',
+  'Pathogen'
+];
+
 /**
  * Performs a recursive upsert into the data source via loopback API calls
  * - Upsert relationship data models first


### PR DESCRIPTION
Restrict the /cms/model/save endpoint, allowing it to only modify those tables which are absolutely necessary to the operation of NORA. Eventually, we want to retire this entire library along with the rest of NORA Core.

The list of allowed tables is hardcoded. There's no need to take the additional risk of storing this in configuration since the library itself is deprecated and is being restricted as part of its end-of-life plan. 